### PR TITLE
Fixes black background on flag with RN 0.40

### DIFF
--- a/src/CountryPicker.style.js
+++ b/src/CountryPicker.style.js
@@ -31,6 +31,7 @@ export default StyleSheet.create({
     height: 30,
     borderWidth: 1 / PixelRatio.get(),
     borderColor: 'transparent',
+    backgroundColor: 'transparent',
   },
   itemCountry: {
     flexDirection: 'row',


### PR DESCRIPTION
In ReactNative 0.40, the flag has black background